### PR TITLE
BulletPointView and dynamic type improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,20 @@ This framework supports iOS, iPadOS, tv)S (15.0 and above) and macOS (12.0 and a
 
 1) In your target's General Settings, make sure your app Display Name is set as you want it.
 
-2) Create the content for each What's New page you want displayed. You can use What's New `BulletPointView` struct to add bullet points with images, bold titles and explanatory text. The component will use whatever accent color you set for the page.
+2) Create the content for each What's New page you want displayed. You can use What's New `BulletPointView` struct to add bullet points with images, bold titles and explanatory text (or any other view). The component will use whatever accent color you set for the page.
 
 ```swift
 struct WhatsNewPageView: View {
     var body: some View {
         VStack (alignment: .leading, spacing: 10){
             BulletPointView(title: "We now have SEARCH!!!",
-                            systemName: "paintbrush.fill",
-                            text: "Search to find books that have been on previous best seller lists.")
+                            systemName: "paintbrush.fill") {
+                Text("Search to find books that have been on previous best seller lists.")
+            }
             BulletPointView(title: "More bugs squashed.",
-                            imageName: "myTruck",
-                            text: "And the hits keep coming")
-                            
+                            imageName: "myTruck") {
+                Text("And the hits keep coming")
+            }
             Spacer()
         }
         .padding()

--- a/Sources/WhatsNew/BulletPointView.swift
+++ b/Sources/WhatsNew/BulletPointView.swift
@@ -60,14 +60,16 @@ public struct BulletPointView: View {
                     .bulletStyle()
                     .font(.title)
             }
-             VStack (alignment: .leading, spacing: 4){
+            VStack (alignment: .leading, spacing: 4){
                 Text(title)
                     .fontWeight(.semibold)
                 Text(text)
                     .foregroundColor(.secondary)
             }
             .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
             .font(.subheadline)
+            .padding(.leading, 4)
             .padding(.bottom, 6)
         }
     }
@@ -91,13 +93,15 @@ extension View {
 #if DEBUG
 struct BulletPointView_Previews: PreviewProvider {
     static var previews: some View {
-        VStack (alignment: .leading){
-            BulletPointView(systemName: "square.and.pencil")
-            BulletPointView(systemName: "hare.fill")
-            BulletPointView(systemName: "circle.fill")
-            BulletPointView(systemName: "car.2.fill")
-            BulletPointView(systemName: "switch.2")
-            BulletPointView(systemName: "ellipsis")
+        ScrollView {
+            VStack (alignment: .leading){
+                BulletPointView(systemName: "square.and.pencil")
+                BulletPointView(systemName: "hare.fill")
+                BulletPointView(systemName: "circle.fill")
+                BulletPointView(systemName: "car.2.fill")
+                BulletPointView(systemName: "switch.2")
+                BulletPointView(systemName: "ellipsis")
+            }
         }.padding()
     }
 }

--- a/Sources/WhatsNew/BulletPointView.swift
+++ b/Sources/WhatsNew/BulletPointView.swift
@@ -66,6 +66,7 @@ public struct BulletPointView: View {
                 Text(text)
                     .foregroundColor(.secondary)
             }
+            .textSelection(.enabled)
             .multilineTextAlignment(.leading)
             .fixedSize(horizontal: false, vertical: true)
             .font(.subheadline)

--- a/Sources/WhatsNew/BulletPointView.swift
+++ b/Sources/WhatsNew/BulletPointView.swift
@@ -11,28 +11,28 @@ import SwiftUI
 
 let frameWidth = 50.0
 
-public struct BulletPointView: View {
+public struct BulletPointView<Content: View>: View {
     let title: String
     let imageName: String?
     let systemName: String?
-    let text : String
+    let content: Content
     
     public init(title: String = "New feature",
                 imageName: String = "circle.fill",
-                text: String = "This is a new feature for this app. And this text should wrap.") {
+                @ViewBuilder content: () -> Content) {
         self.title = title
         self.imageName = imageName
         self.systemName = nil
-        self.text = text
+        self.content = content()
     }
     
     public init(title: String = "New feature",
                 systemName: String = "circle.fill",
-                text: String = "This is a new feature for this app with a system icon. And this text should wrap.") {
+                @ViewBuilder content: () -> Content) {
         self.title = title
         self.imageName = nil
         self.systemName = systemName
-        self.text = text
+        self.content = content()
     }
 
     public var body: some View {
@@ -63,7 +63,7 @@ public struct BulletPointView: View {
             VStack (alignment: .leading, spacing: 4){
                 Text(title)
                     .fontWeight(.semibold)
-                Text(text)
+                content
                     .foregroundColor(.secondary)
             }
             .textSelection(.enabled)
@@ -96,12 +96,24 @@ struct BulletPointView_Previews: PreviewProvider {
     static var previews: some View {
         ScrollView {
             VStack (alignment: .leading){
-                BulletPointView(systemName: "square.and.pencil")
-                BulletPointView(systemName: "hare.fill")
-                BulletPointView(systemName: "circle.fill")
-                BulletPointView(systemName: "car.2.fill")
-                BulletPointView(systemName: "switch.2")
-                BulletPointView(systemName: "ellipsis")
+                BulletPointView(systemName: "square.and.pencil") {
+                    Text("Bullet point 1")
+                }
+                BulletPointView(systemName: "hare.fill") {
+                    Text("Bullet point 2")
+                }
+                BulletPointView(systemName: "circle.fill") {
+                    Text("Bullet point 3")
+                }
+                BulletPointView(systemName: "car.2.fill") {
+                    Text("Bullet point 4")
+                }
+                BulletPointView(systemName: "switch.2") {
+                    Text("Bullet point 5")
+                }
+                BulletPointView(systemName: "ellipsis") {
+                    Text("Bullet point 6")
+                }
             }
         }.padding()
     }

--- a/Sources/WhatsNew/WhatsNewView.swift
+++ b/Sources/WhatsNew/WhatsNewView.swift
@@ -79,14 +79,17 @@ struct WhatsNewView_Previews: PreviewProvider {
         WhatsNewView(multiPage: false, appName: "Full App Name") {
             VStack (alignment: .leading) {
                 BulletPointView(title: "New feature",
-                                systemName: "circle.fill",
-                                text: "This is a new feature for this app. And this text should wrap.")
+                                systemName: "circle.fill") {
+                    Text("This is a new feature for this app. And this text should wrap.")
+                }
                 BulletPointView(title: "New feature",
-                                systemName: "square.fill",
-                                text: "This is a new feature for this app. And this text should wrap.")
+                                systemName: "square.fill") {
+                    Text("This is a new feature for this app. And this text should wrap.")
+                }
                 BulletPointView(title: "New feature",
-                                systemName: "triangle.fill",
-                                text: "This is a new feature for this app. And this text should wrap.")
+                                systemName: "triangle.fill") {
+                    Text("This is a new feature for this app. And this text should wrap.")
+                }
             }
         }
     }

--- a/Sources/WhatsNew/WhatsNewView.swift
+++ b/Sources/WhatsNew/WhatsNewView.swift
@@ -15,13 +15,15 @@ public struct WhatsNewView<Content: View>: View {
     var appName: String
     let multiPage: Bool
     let showVersion: Bool
+    let showBuild: Bool
     let content: Content
     
     private let bundle = Bundle.module
     
-    public init(multiPage: Bool = true, showVersion: Bool = true, appName: String? = nil, @ViewBuilder contentProvider: () -> Content) {
+    public init(multiPage: Bool = true, showVersion: Bool = true, showBuild: Bool = true, appName: String? = nil, @ViewBuilder contentProvider: () -> Content) {
         self.multiPage = multiPage
         self.showVersion = showVersion
+        self.showBuild = showBuild
         self.content = contentProvider()
         if let appName = appName {
             self.appName = appName
@@ -35,8 +37,8 @@ public struct WhatsNewView<Content: View>: View {
             VStack (alignment: .center) {
                 Text(String(format:NSLocalizedString("What's New\nin %@", bundle: bundle, comment: "Dialog Title"), appName))
                     .fontWeight(.bold)
-                if showVersion, let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,  let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String{
-                    Text("v\(version).\(build)")
+                if showVersion, let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,  let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+                    Text(verbatim: showBuild ? "v\(version).\(build)" : "v\(version)")
                         .font(.footnote)
                         .textSelection(.enabled)
                         .padding(.top)

--- a/Sources/WhatsNew/WhatsNewView.swift
+++ b/Sources/WhatsNew/WhatsNewView.swift
@@ -12,17 +12,22 @@ public struct WhatsNewView<Content: View>: View {
     
     @Environment(\.presentationMode) var presentationMode
 
-    let appName: String = Bundle.main.localizedInfoDictionary?["CFBundleDisplayName"] as? String ?? "My App"
+    var appName: String
     let multiPage: Bool
     let showVersion: Bool
     let content: Content
     
     private let bundle = Bundle.module
     
-    public init(multiPage: Bool = true, showVersion: Bool = true, @ViewBuilder contentProvider: () -> Content) {
+    public init(multiPage: Bool = true, showVersion: Bool = true, appName: String? = nil, @ViewBuilder contentProvider: () -> Content) {
         self.multiPage = multiPage
         self.showVersion = showVersion
         self.content = contentProvider()
+        if let appName = appName {
+            self.appName = appName
+        } else {
+            self.appName = Bundle.main.localizedInfoDictionary?["CFBundleDisplayName"] as? String ?? "My App"
+        }
     }
         
     public var body: some View {
@@ -70,7 +75,7 @@ public struct WhatsNewView<Content: View>: View {
 #if DEBUG
 struct WhatsNewView_Previews: PreviewProvider {
     static var previews: some View {
-        WhatsNewView(multiPage: false) {
+        WhatsNewView(multiPage: false, appName: "Full App Name") {
             VStack (alignment: .leading) {
                 BulletPointView(title: "New feature",
                                 systemName: "circle.fill",

--- a/Sources/WhatsNew/WhatsNewView.swift
+++ b/Sources/WhatsNew/WhatsNewView.swift
@@ -38,6 +38,7 @@ public struct WhatsNewView<Content: View>: View {
                 if showVersion, let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
                     Text("v\(version)")
                         .font(.footnote)
+                        .textSelection(.enabled)
                         .padding(.top)
                 }
             }

--- a/WhatsNewDemo/WhatsNewDemo.xcodeproj/xcshareddata/xcschemes/WhatsNewDemo.xcscheme
+++ b/WhatsNewDemo/WhatsNewDemo.xcodeproj/xcshareddata/xcschemes/WhatsNewDemo.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EA054FA32A4E52B10046251E"
+               BuildableName = "WhatsNewDemo.app"
+               BlueprintName = "WhatsNewDemo"
+               ReferencedContainer = "container:WhatsNewDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "fr"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EA054FA32A4E52B10046251E"
+            BuildableName = "WhatsNewDemo.app"
+            BlueprintName = "WhatsNewDemo"
+            ReferencedContainer = "container:WhatsNewDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EA054FA32A4E52B10046251E"
+            BuildableName = "WhatsNewDemo.app"
+            BlueprintName = "WhatsNewDemo"
+            ReferencedContainer = "container:WhatsNewDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WhatsNewDemo/WhatsNewDemo/PageView.swift
+++ b/WhatsNewDemo/WhatsNewDemo/PageView.swift
@@ -19,14 +19,18 @@ struct PageView: View {
                     .multilineTextAlignment(.center)
                 
                 BulletPointView(title: "We now have SEARCH!!!",
-                                systemName: "paintbrush.fill",
-                                text: "Search to find books that have been on previous best seller lists.")
+                                systemName: "paintbrush.fill") {
+                    Text("Search to find books that have been on previous best seller lists.")
+                }
                 BulletPointView(title: "We now have OTHER STUFF!!!",
-                                systemName: "ant",
-                                text: "Search to find books that have been on previous best seller lists.")
+                                systemName: "ant") {
+                    Text("Search to find books that have been on previous best seller lists.")
+                    Toggle("Toggle", isOn: .constant(true))
+                }
                 BulletPointView(title: "More bugs squashed.",
-                                imageName: "Truck",
-                                text: "And the hits keep coming")
+                                imageName: "Truck") {
+                    Text("And the hits keep coming")
+                }
                 
                 Spacer()
             }

--- a/WhatsNewDemo/WhatsNewDemo/PageView.swift
+++ b/WhatsNewDemo/WhatsNewDemo/PageView.swift
@@ -20,6 +20,9 @@ struct PageView: View {
             BulletPointView(title: "We now have SEARCH!!!",
                             systemName: "paintbrush.fill",
                             text: "Search to find books that have been on previous best seller lists.")
+            BulletPointView(title: "We now have OTHER STUFF!!!",
+                            systemName: "ant",
+                            text: "Search to find books that have been on previous best seller lists.")
             BulletPointView(title: "More bugs squashed.",
                             imageName: "Truck",
                             text: "And the hits keep coming")

--- a/WhatsNewDemo/WhatsNewDemo/PageView.swift
+++ b/WhatsNewDemo/WhatsNewDemo/PageView.swift
@@ -12,25 +12,27 @@ struct PageView: View {
     let page: Int
     
     var body: some View {
-        VStack (alignment: .leading, spacing: 10){
-            Text("This is page \(page)")
-                .font(.title)
-                .multilineTextAlignment(.center)
-            
-            BulletPointView(title: "We now have SEARCH!!!",
-                            systemName: "paintbrush.fill",
-                            text: "Search to find books that have been on previous best seller lists.")
-            BulletPointView(title: "We now have OTHER STUFF!!!",
-                            systemName: "ant",
-                            text: "Search to find books that have been on previous best seller lists.")
-            BulletPointView(title: "More bugs squashed.",
-                            imageName: "Truck",
-                            text: "And the hits keep coming")
-            
-            Spacer()
+        ScrollView {
+            VStack (alignment: .leading, spacing: 10){
+                Text("This is page \(page)")
+                    .font(.title)
+                    .multilineTextAlignment(.center)
+                
+                BulletPointView(title: "We now have SEARCH!!!",
+                                systemName: "paintbrush.fill",
+                                text: "Search to find books that have been on previous best seller lists.")
+                BulletPointView(title: "We now have OTHER STUFF!!!",
+                                systemName: "ant",
+                                text: "Search to find books that have been on previous best seller lists.")
+                BulletPointView(title: "More bugs squashed.",
+                                imageName: "Truck",
+                                text: "And the hits keep coming")
+                
+                Spacer()
+            }
+            .padding()
+            .accentColor(Color.red)
         }
-        .padding()
-        .accentColor(Color.red)
     }
 }
 


### PR DESCRIPTION
A few improvements on my end that may be of interest to other users:

- Better support for Dynamic Type that makes sure the dialog is readable with all font sizes.
- `BulletPointView` is now a view builder, allowing to put more than just text inside of it.
- Allows to override the app name from the plist (sometimes it differs from the marketing name for longer app names)
- Enable text selection